### PR TITLE
Fix master docker build due to tag beaing latest and not master

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
-            ${{ github.ref == 'refs/heads/master' && 'ghcr.io/${{ github.repository }}:latest' || '' }}
+            ${{ github.ref == 'refs/heads/master' && 'ghcr.io/${{ github.repository }}:master' || '' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           build-args: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,8 +67,9 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
-            ${{ github.ref == 'refs/heads/master' && 'ghcr.io/${{ github.repository }}:master' || '' }}
+            ${{ github.ref == 'refs/heads/master' && format('ghcr.io/{0}:master', github.repository) || '' }}
+            ${{ github.ref == 'refs/heads/dev' && format('ghcr.io/{0}:dev', github.repository) || '' }}
+            ${{ !startsWith(github.ref, 'refs/heads/') && format('ghcr.io/{0}:{1}', github.repository, github.sha) || '' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           build-args: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-publish.yml` file. The change updates the tag for the master branch to use `master` instead of `latest`.

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L71-R71): Changed the tag for the master branch from `latest` to `master`.