### PR TITLE
Add status widgets and re enable blog post recent

### DIFF
--- a/src/components/status-widget.astro
+++ b/src/components/status-widget.astro
@@ -1,0 +1,61 @@
+---
+interface Props {
+  apiUrl?: string;
+}
+
+const { apiUrl = 'https://status.husky.nz' } = Astro.props;
+
+interface Service {
+  id: number;
+  name: string;
+  status: string;
+  online: boolean;
+  latency: number;
+}
+
+const fetchServices = async () => {
+  try {
+    const response = await fetch(`${apiUrl}/api/services`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    
+    const contentType = response.headers.get("content-type") || '';
+    if (contentType && !contentType.toLowerCase().includes('json')) {
+      console.warn('Unexpected content-type:', contentType);
+    }
+
+    const data = await response.json();
+    return data as Service[];
+  } catch (error) {
+    console.error('Error fetching services:', error);
+    return [] as Service[];
+  }
+};
+
+const services = await fetchServices();
+---
+
+<div class="p-4 flex flex-col justify-center items-center w-full">
+  <h2 class="text-2xl font-semibold mb-6">Status of HuskyNZ Services</h2>
+  {services.length === 0 ? (
+    <p class="text-red-600 text-center">Unable to load services status</p>
+  ) : (
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 w-full max-w-7xl mx-auto">
+      {services.map((service) => (
+        <a 
+          href={`https://status.husky.nz/service/${service.id}`} 
+          class="border border-gray-200/20 rounded-lg p-4 flex flex-col items-center justify-center hover:bg-gray-100/10 transition-colors duration-200"
+        >
+          <span class={`w-3 h-3 rounded-full mb-2 ${
+            service.online ? 'bg-green-500/80' : 'bg-red-600/80'
+          }`}></span>
+          <span class="text-center mb-1">{service.name}</span>
+          <span class="text-gray-500 text-sm">
+            {service.online ? 'Service is up' : 'Service is down'}
+          </span>
+        </a>
+      ))}
+    </div>
+  )}
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,8 @@ import MeteorShower from "@components/MeteorShower.astro"
 import Twitch from "@components/TwitchEmbed.astro"
 import GitHubActivity from "@components/GitHubActivity.astro"
 import ContactForm from '@components/ContactForm.astro';
+import StatusWidget from "@components/status-widget.astro"
+import ArrowCard from "@components/ArrowCard.tsx"
 
 
 
@@ -123,11 +125,13 @@ phClient.capture(
             <TimelineSkills />
           </section>
           --> 
+          <section class="animate flex justify-center items-center w-full">
+            <StatusWidget />
+          </section>
           <!-- Twitch Embed, Displays message when offline - Reanable later -->
           <section id="contact" class="animate">
             <Twitch />
             </section>
-
       <!-- Contact Section -->
       <section id="contact" class="animate scroll-mt-32">
         <div>
@@ -165,7 +169,7 @@ phClient.capture(
           <ContactForm />
         </div>
       </section>
-      <!-- Blog Preview Section
+      <!-- Blog Preview Section-->
       <section class="animate">
         <div class="space-y-4">
           <div class="flex justify-between">
@@ -187,7 +191,7 @@ phClient.capture(
           </ul>
         </div>
       </section>
-     -->
+     
     </div>
   </div>
 


### PR DESCRIPTION
This pull request adds a new status widget component and integrates it into the homepage. The most important changes include creating the `StatusWidget` component, updating the homepage to include this new component, and some minor formatting adjustments.

### New Component Addition:

* [`src/components/status-widget.astro`](diffhunk://#diff-a414fccfb532725aca11262bd6d9ed00c18c7cc303332e21e2856004122dafc4R1-R61): Created a new `StatusWidget` component that fetches and displays the status of HuskyNZ services. The component includes an interface for props and services, a function to fetch service data, and a template to render the service status.

### Homepage Integration:

* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R11-R12): Imported the `StatusWidget` component and added a new section to display it on the homepage. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R11-R12) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R128-L130)

### Formatting Adjustments:

* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L168-R172): Fixed a comment formatting issue and removed an unnecessary comment closure. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L168-R172) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L190-R194)