### PR TITLE
Add some more things to the timeline

### DIFF
--- a/src/components/TimelineSkills.astro
+++ b/src/components/TimelineSkills.astro
@@ -77,7 +77,9 @@ const timeline: TimelineEvent[] = [
     year: "2025",
     events: [
       "HP remote management",
-      "Setup Microsoft Configuration Manager in my homelab"
+      "Setup Microsoft Configuration Manager in my homelab",
+      "Setup A SAN in my homelab to Learn and Understand network storage",
+      "Setup Citrix Virtual Apps and Desktop and intrgrated with ESXi and Vcenter to auto provisioning and deployment of VDI vm's"
     ]
   }
 ];


### PR DESCRIPTION
Added 
      "Setup A SAN in my homelab to Learn and Understand network storage",
      "Setup Citrix Virtual Apps and Desktop and intrgrated with ESXi and Vcenter to auto provisioning and deployment of VDI vm's"
to the Skills timeline 

Also

Should move this json to a separate service at some point  / Build a editor for it.. Possibley a addon and or base it off the HuskyNZ URL shorten (A new route and or copy code) to allow quick adding and removing of skills